### PR TITLE
Update for Selenium 4.10 compatibility

### DIFF
--- a/pyhtml2pdf/converter.py
+++ b/pyhtml2pdf/converter.py
@@ -4,6 +4,7 @@ import base64
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support.expected_conditions import staleness_of
@@ -72,9 +73,8 @@ def __get_pdf_from_html(
     webdriver_prefs["profile.default_content_settings"] = {"images": 2}
 
     if install_driver:
-        driver = webdriver.Chrome(
-            ChromeDriverManager().install(), options=webdriver_options
-        )
+        service = Service(ChromeDriverManager().install())
+        driver = webdriver.Chrome(service=service, options=webdriver_options)
     else:
         driver = webdriver.Chrome(options=webdriver_options)
 

--- a/pyhtml2pdf/converter.py
+++ b/pyhtml2pdf/converter.py
@@ -30,6 +30,7 @@ def convert(
     :param int timeout: timeout in seconds. Default value is set to 2 seconds
     :param bool compress: whether PDF is compressed or not. Default value is False
     :param int power: power of the compression. Default value is 0. This can be 0: default, 1: prepress, 2: printer, 3: ebook, 4: screen
+    :param bool install_driver: whether or not to install using ChromeDriverManager. Default value is True
     :param dict print_options: options for the printing of the PDF. This can be any of the params in here:https://vanilla.aslushnikov.com/?Page.printToPDF
     """
 


### PR DESCRIPTION
Some things broke with Selenium 4.10 which removed some deprecated options and changed the arguments to webdriver.Chrome(). This led to things like this error:
`TypeError: __init__() got multiple values for argument 'options'`