### PR TITLE
Windows bugfix

### DIFF
--- a/pyhtml2pdf/compressor.py
+++ b/pyhtml2pdf/compressor.py
@@ -64,7 +64,7 @@ def compress(source: str | os.PathLike | _TemporaryFileWrapper,
                     )
 
 
-def __compress(result: bytes,
+def _compress(result: bytes,
                target: str | os.PathLike,
                power: int,
                ghostscript_command: str | None):

--- a/pyhtml2pdf/compressor.py
+++ b/pyhtml2pdf/compressor.py
@@ -1,18 +1,30 @@
 import os
-import sys
+import platform
 import subprocess
+from pathlib import Path
+from tempfile import NamedTemporaryFile, _TemporaryFileWrapper
 
-from shutil import copyfile, rmtree
 
-def compress(source: str, target: str, power: int = 0):
-    '''
-    Compress a given PDF file
+def compress(source: str | os.PathLike | _TemporaryFileWrapper,
+             target: str | os.PathLike,
+             power: int = 0,
+             ghostscript_command: str = None) -> None:
+    """
 
-    :param str source: source PDF file
-    :param str target: target location to save the compressed PDF
-    :param int power: power of the compression. Default value is 0. This can be 0: default, 1: prepress, 2: printer, 3: ebook, 4: screen
-   '''
-
+    :param source: Source PDF file
+    :param target: Target location to save the compressed PDF
+    :param power: Power of the compression. Default value is 0. This can be
+                    0: default,
+                    1: prepress,
+                    2: printer,
+                    3: ebook,
+                    4: screen
+    :param ghostscript_command: The name of the ghostscript executable. If set to the default value None, is attempted
+                                to be inferred from the OS.
+                                If the OS is not Windows, "gs" is used as executable name.
+                                If the OS is Windows, and it is a 64-bit version, "gswin64c" is used. If it is a 32-bit
+                                version, "gswin32c" is used.
+    """
     quality = {
         0: '/default',
         1: '/prepress',
@@ -21,31 +33,42 @@ def compress(source: str, target: str, power: int = 0):
         4: '/screen'
     }
 
-    if not os.path.isfile(source):
-        print('Error: invalid path for input PDF file')
-        sys.exit(1)
+    if ghostscript_command is None:
+        if platform.system() == 'Windows':
+            if platform.machine().endswith('64'):
+                ghostscript_command = 'gswin64c'
+            else:
+                ghostscript_command = 'gswin32c'
+        else:
+            ghostscript_command = 'gs'
 
-    if source.split('.')[-1].lower() != 'pdf':
-        print('Error: input file is not a PDF')
-        sys.exit(1)
+    if isinstance(source, _TemporaryFileWrapper):
+        source = source.name
 
-    initial_size = os.path.getsize(source)
-    subprocess.call(['gs', '-sDEVICE=pdfwrite', '-dCompatibilityLevel=1.4',
+    source = Path(source)
+    target = Path(target)
+
+    if not source.is_file():
+        raise FileNotFoundError('invalid path for input PDF file')
+
+    if source.suffix != '.pdf':
+        raise ValueError('Input file must be a .pdf file')
+
+    subprocess.call([ghostscript_command,
+                     '-sDEVICE=pdfwrite', '-dCompatibilityLevel=1.4',
                      '-dPDFSETTINGS={}'.format(quality[power]),
                      '-dNOPAUSE', '-dQUIET', '-dBATCH',
-                     '-sOutputFile={}'.format(target),
-                     source]
+                     '-sOutputFile={}'.format(target.as_posix()),
+                     source.as_posix()],
+                    shell=platform.system() == 'Windows'
                     )
 
-def __compress(result, target: str, power: int):
-    tmp_dir: str = './_tmp'
-    tmp_file: str = f'{tmp_dir}/tmp.pdf'
 
-    if not os.path.exists(tmp_dir):
-        os.makedirs(tmp_dir)
+def __compress(result: bytes,
+               target: str | os.PathLike,
+               power: int,
+               ghostscript_command: str | None):
+    with NamedTemporaryFile(suffix='.pdf', delete=platform.system() != 'Windows') as tmp_file:
+        tmp_file.write(result)
 
-    with open(tmp_file, 'wb') as file:
-        file.write(result)   
-
-    compress(tmp_file, target, power)
-    rmtree(tmp_dir)
+        compress(tmp_file, target, power, ghostscript_command)

--- a/pyhtml2pdf/converter.py
+++ b/pyhtml2pdf/converter.py
@@ -10,7 +10,7 @@ from selenium.webdriver.support.expected_conditions import staleness_of
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
 
-from .compressor import __compress
+from .compressor import _compress
 
 
 def convert(
@@ -46,7 +46,7 @@ def convert(
         source, timeout, install_driver, print_options)
 
     if compress:
-        __compress(result, target, power, ghostscript_command)
+        _compress(result, target, power, ghostscript_command)
     else:
         with open(target, "wb") as file:
             file.write(result)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pyhtml2pdf", # Replace with your own username
-    version="0.0.6",
+    version="0.0.8rc1",
     author="Kumara Fernando",
     author_email="mklmfernando@gmail.com",
     description="Simple python wrapper to convert HTML to PDF with headless Chrome via selenium.",


### PR DESCRIPTION
The package did not work correctly when using compression on a Windows OS system. The issue stemmed from how the `subprocess.call` method was called, and with the way that a temporary file was created.